### PR TITLE
Simplify test invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,19 +10,4 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
-prove_installcheck: $(pgxsdir)/src/test/perl/$(core_perl_module)
-	rm -rf $(CURDIR)/tmp_check
-	mkdir -p $(CURDIR)/tmp_check &&\
-		PERL5LIB="$${PERL5LIB}:$(srcdir)/t:$(pgxsdir)/src/test/perl" \
-		PG_VERSION_NUM='$(VERSION_NUM)' \
-		TESTDIR='$(CURDIR)' \
-		SRCDIR='$(srcdir)' \
-		PATH="$(TEST_PATH_PREFIX):$(PATH)" \
-		PGPORT='6$(DEF_PGPORT)' \
-		top_builddir='$(CURDIR)/tmp_check' \
-		PG_REGRESS='$(pgxsdir)/src/test/regress/pg_regress' \
-		PGCTLTIMEOUT=180 \
-		$(PROVE) $(PG_PROVE_FLAGS) $(PROVE_FLAGS) \
-		$(addprefix $(srcdir)/,$(or $(PROVE_TESTS),t/*.pl))
-
-check_prove: prove_installcheck
+export PGCTLTIMEOUT = 180


### PR DESCRIPTION
As of PostgreSQL commit postgres/postgres@5d42a97519581a31bdc1d3d4cf10c07ae18b8296 (and backpatches thereof, released May 2023), the out-of-the-box installcheck target of PGXS should work for TAP tests again, so we remove all the custom code.