### PR TITLE
Do not drop any physical slots on standby.

### DIFF
--- a/pg_failover_slots.c
+++ b/pg_failover_slots.c
@@ -945,6 +945,10 @@ synchronize_failover_slots(long sleep_time)
 			if (!s->in_use || active)
 				continue;
 
+			/* Only check for logical slots. */
+			if (SlotIsPhysical(s))
+				continue;
+
 			/* Try to find slot in slots returned by primary. */
 			foreach (lc, slots)
 			{


### PR DESCRIPTION
At present, this tool synchronizes the logical slots from primary to standby. So it makes no sense to drop a physical slot on standby, regardless of whether it is present on the primary or not.