### PR TITLE
Update Makefile to allow pg_failover_slots extension to be build without pg_config binary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,15 @@ SHLIB_LINK += $(libpq)
 
 TAP_TESTS = 1
 
+ifdef USE_PGXS
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/pg_failover_slots
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif
 
 export PGCTLTIMEOUT = 180


### PR DESCRIPTION
Currently we need the pg_config binary to build the pg_failover_slots extension/module. This PR makes changes to the Makefile so that it can be built from within the contrib folder without having any dependency on the pg_config binary.