### PR TITLE
Make hardcoded defaults into GUC

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ confirm before we send data through the logical replication
 slots. Setting -1 (the default) means to wait for all entries in
 `pg_failover_slots.standby_slot_names`.
 
+### pg_failover_slots.worker_nap_time
+
+Time to sleep (in ms) between two synchronisation attempts. Defaults to 60s.
+
+### pg_failover_slots.maintenance_db
+
+Database name to use when using primary_conninfo to connect to the primary server and fetch the replication slots list.
+Defaults to `postgres`.
+
 
 ## Release notes
 

--- a/pg_failover_slots.c
+++ b/pg_failover_slots.c
@@ -105,6 +105,7 @@ XLogRecPtr standby_slot_names_oldest_flush_lsn = InvalidXLogRecPtr;
 
 /* Various configuration */
 int worker_nap_time;
+char *pg_failover_maintenance_db;
 
 /* Slots to sync */
 char *pg_failover_slots_dsn;
@@ -445,6 +446,7 @@ get_database_oid(const char *dbname)
 static void
 make_sync_failover_slots_dsn(StringInfo connstr, char *db_name)
 {
+	Assert(db_name);
 	if (pg_failover_slots_dsn && strlen(pg_failover_slots_dsn) > 0)
 	{
 		if (db_name)
@@ -456,8 +458,7 @@ make_sync_failover_slots_dsn(StringInfo connstr, char *db_name)
 	else
 	{
 		Assert(WalRcv);
-		appendStringInfo(connstr, "%s dbname=%s", WalRcv->conninfo,
-						 db_name ? db_name : "postgres");
+		appendStringInfo(connstr, "%s dbname=%s", WalRcv->conninfo, db_name);
 	}
 }
 
@@ -902,7 +903,7 @@ synchronize_failover_slots(long sleep_time)
 	elog(DEBUG1, "starting replication slot synchronization from primary");
 
 	initStringInfo(&connstr);
-	make_sync_failover_slots_dsn(&connstr, NULL /* Use default db name */);
+	make_sync_failover_slots_dsn(&connstr, pg_failover_maintenance_db);
 	conn = remote_connect(connstr.data, "pg_failover_slots");
 
 	/*
@@ -1482,6 +1483,14 @@ _PG_init(void)
 		NULL,
 		&worker_nap_time, 60000, 1000, INT_MAX, PGC_SIGHUP,
 		GUC_SUPERUSER_ONLY | GUC_UNIT_MS, NULL, NULL, NULL);
+
+	DefineCustomStringVariable(
+		"pg_failover_slots.maintenance_db",
+		"Database to connect to when using the primary_conninfo",
+		"When connecting to the primary using the primary_conninfo instead of a specifically set "
+		"pg_failover_slots.primary_dsn, use this datbase to query the pg_replication_slots view.",
+		&pg_failover_maintenance_db, "postgres", PGC_SIGHUP, GUC_SUPERUSER_ONLY,
+		NULL, NULL, NULL);
 
 
 	if (IsBinaryUpgrade)


### PR DESCRIPTION
This PR replaces the hardcoded WORKER_NAP_TIME by a GUC, and the hardcoded default database name "postgres" to another GUC.