### PR TITLE
Fix how flush_pos is compared to commit_lsn.

### DIFF
--- a/pg_failover_slots.c
+++ b/pg_failover_slots.c
@@ -1164,7 +1164,7 @@ skip_standby_slot_names(XLogRecPtr commit_lsn)
 	 * skip checks entirely. The assignment hook for
 	 * pg_failover_slots.standby_slot_names invalidates the cache.
 	 */
-	if (standby_slot_names_oldest_flush_lsn >= commit_lsn ||
+	if (standby_slot_names_oldest_flush_lsn > commit_lsn ||
 		standby_slots_min_confirmed == 0 ||
 		list_length(standby_slot_names) == 0)
 		return true;
@@ -1247,7 +1247,7 @@ wait_for_standby_confirmation(XLogRecPtr commit_lsn)
 				oldest_flush_pos > flush_pos)
 				oldest_flush_pos = flush_pos;
 
-			if (flush_pos >= commit_lsn && wait_slots_remaining > 0)
+			if (flush_pos > commit_lsn && wait_slots_remaining > 0)
 				wait_slots_remaining--;
 		}
 		LWLockRelease(ReplicationSlotControlLock);


### PR DESCRIPTION
When we logically replicate the message with LSN equal to exactly X, we need to wait for `flush_pos` of other replicas to become strictly greater than X, not greater or equal.

Both `restart_lsn` and `confirmed_flush` represent the oldest LSN that must still be kept so it can still be replicated. That means that it might NOT yet be replicated.

--

I made some trivial experiment to check how `pg_failover_slots.standby_slot_names` behaves and noticed that my logical replica always gets one extra record when the physical replica becomes unavailable. With this fix it works as expected: logical replica is never delayed more then necessary, but no records that were not replicated to physical replica are replicated to the logical one.