### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ Defaults to `postgres`.
 ## Release notes
 
 
+### v1.2.2
+
+Version 1.2.2 contains a packaging fix.
+
+ - Create a new release because the last release (1.2.1) points to the
+   incorrect commit.
+
 ### v1.2.1
 
 Version 1.2.1 contains a bug fix.

--- a/pg_failover_slots.c
+++ b/pg_failover_slots.c
@@ -60,7 +60,7 @@
 #include "libpq/auth.h"
 #include "libpq/libpq.h"
 
-#define PG_FAILOVER_SLOTS_VERSION "1.2.1"
+#define PG_FAILOVER_SLOTS_VERSION "1.2.2"
 
 PG_MODULE_MAGIC;
 


### PR DESCRIPTION
Due to the tag (1.2.1) pointing to an incorrect commit, let's create a new release.  The previous release (1.2.1) should not be used because it contains the wrong version string.